### PR TITLE
add Makefile and fix textcomp error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+filename:=thesis
+
+.PHONY: all clean
+
+all:
+	platex -shell-escape $(filename).tex
+	pbibtex $(filename).aux
+	platex $(filename).tex
+	platex $(filename).tex
+	dvipdfmx $(filename).dvi
+
+clean:
+	@rm -f $(filename).pdf *.aux *.dvi *.log *.nav *.out *.snm *.toc *.xbb *.lof *.lot *.thm *.bbl *.blg
+

--- a/thesis.tex
+++ b/thesis.tex
@@ -8,7 +8,7 @@
 \usepackage{pxjahyper}
 \usepackage{amsmath,amssymb}
 \usepackage[amsmath,thmmarks]{ntheorem}
-\usepackage{textcomp}
+\usepackage[full]{textcomp}
 \usepackage{newtxtext}
 \usepackage[scaled]{helvet}
 \usepackage{bm}


### PR DESCRIPTION
## Fix  package `textcomp` compile-error

TexLive 2016 will throw an error about the `textcomp` package.

## Add Makefile to simple the compiling steps

### Compile

    $ make

### Clean

    $ make clean